### PR TITLE
Add missing colon to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We appreciate the use of topic branches.
 
     # update enhance the documentation
 
-    git commit -m "<JIRA issue number> This is my commit message."
+    git commit -m "<JIRA issue number>: This is my commit message."
 
     git push origin <JIRA issue number>
 


### PR DESCRIPTION
It seems that colons (`:`) are used to seperate the issue number from the commit message. I added this to the howto.