### PR TITLE
PDFBOX-5475: remove period from "via. javadoc.io"

### DIFF
--- a/content/_layouts/default.html
+++ b/content/_layouts/default.html
@@ -47,7 +47,7 @@
                         <a href="#">3.0 (Pre Release)</a>
                         <ul>
                             <li><a href="/3.0/migration.html">Migration Guide</a></li>
-                            <li><a href="https://javadoc.io/doc/org.apache.pdfbox/pdfbox/3.0.0-alpha3/index.html">API Docs&emsp;<small>via. javadoc.io</small></a></li>
+                            <li><a href="https://javadoc.io/doc/org.apache.pdfbox/pdfbox/3.0.0-alpha3/index.html">API Docs&emsp;<small>via javadoc.io</small></a></li>
                         </ul>
                     </li>
                     <li class="sidebar-node" id="v2-0">
@@ -65,7 +65,7 @@
                             </li>
                             <li><a href="/2.0/commandline.html">Command-Line Tools</a></li>
                             <li><a href="/2.0/faq.html">FAQ</a></li>
-                            <li><a href="https://javadoc.io/doc/org.apache.pdfbox/pdfbox/2.0.26/index.html">API Docs&emsp;<small>via. javadoc.io</small></a></li>
+                            <li><a href="https://javadoc.io/doc/org.apache.pdfbox/pdfbox/2.0.26/index.html">API Docs&emsp;<small>via javadoc.io</small></a></li>
                         </ul>
                     </li>
                     <li class="sidebar-node" id="v1-8">
@@ -87,7 +87,7 @@
                                 </ul>
                             </li>
                             <li><a href="/1.8/commandline.html">Command-Line Tools</a></li>
-                            <li><a href="https://javadoc.io/doc/org.apache.pdfbox/pdfbox/1.8.16/index.html">API Docs&emsp;<small>via. javadoc.io</small></a></li>
+                            <li><a href="https://javadoc.io/doc/org.apache.pdfbox/pdfbox/1.8.16/index.html">API Docs&emsp;<small>via javadoc.io</small></a></li>
                             <li><a href="/1.8/faq.html">FAQ</a></li>
                         </ul>
                     </li>

--- a/content/_layouts/documentation.html
+++ b/content/_layouts/documentation.html
@@ -57,7 +57,7 @@
         {%- endfor -%}
         <li>
           <a href="https://javadoc.io/doc/org.apache.pdfbox/pdfbox/{{ release }}/index.html" {% if link.active %}aria-current="page"{% endif %}>
-            API Docs&emsp;<small>via. javadoc.io</small>
+            API Docs&emsp;<small>via javadoc.io</small>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
PDFBOX-5475: remove period from "via. javadoc.io" to make it "via javadoc.io"