### PR TITLE
Add a how-to section for IntelliJ IDEA users

### DIFF
--- a/content/codingconventions.md
+++ b/content/codingconventions.md
@@ -139,9 +139,11 @@ public class Foo extends Bar
 
 ## Eclipse Formatter
 
-Eclipse users may download this preferences file: pdfbox-eclipse-formatter.xml and import this into Eclipse.
-(Window->Preferences, go to Java->Code Style->Formatter and click "Import...").
-Once you have done this you can reformat your code by using Source->Format (Ctrl+Shift+F).
+**Eclipse** users may download this preferences file: `pdfbox-eclipse-formatter.xml` and import this into Eclipse.
+(*Window->Preferences*, go to *Java->Code Style->Formatter* and click "*Import...*").
+Once you have done this you can reformat your code by using *Source->Format* (`Ctrl+Shift+F`).
 
 Also note that Eclipse will automatically format your import statements appropriately when
-you invoke Source -> Organize Imports (Ctrl+Shift+O).
+you invoke *Source -> Organize Imports* (`Ctrl+Shift+O`).
+
+**IntelliJ IDEA** users may leverage the same format preferences by importing them into [Adapter for Eclipse Code Formatter](https://plugins.jetbrains.com/plugin/6546-adapter-for-eclipse-code-formatter) plugin. To make the code conform to the format rules, run *Code -> Reformat Code* command (`Ctrl+Alt+L`) and/or make sure to set the same named flag in *Commit* dialog.


### PR DESCRIPTION
This PR appends _Eclipse Formatter_ section of [Coding Conevtions](https://pdfbox.apache.org/codingconventions.html) page with a short description of how to make use of `pdfbox-eclipse-formatter.xml` file in IntelliJ IDEA.

It also introduces some formatting to the existing text of the section to make it a bit easier to read.


_Disclaimer._ I'm not the author nor a maintainer of the Eclipse formatter plugin for IntelliJ IDEA. The link to the plugin home page is provided exclusively for the readers convinience.  