### PR TITLE
Add dynamic-pdf-tables to the layout libraries list in the 3.0 FAQ

### DIFF
--- a/content/3.0/faq.md
+++ b/content/3.0/faq.md
@@ -164,6 +164,7 @@ PDFBox being a low level PDF library provides the APIs to create page content su
 But PDFBox is the foundation of some projects which might help in that case. This includes projects such as
 - [Boxable](http://dhorions.github.io/boxable/)
 - [BoxTable](https://github.com/errt/BoxTable)
+- [dynamic-pdf-tables](https://github.com/the13thclown/dynamic-pdf-tables)
 - [easytable](https://github.com/vandeseer/easytable)
 - [pdfbox-layout](https://github.com/ralfstuckert/pdfbox-layout)
 - [PdfLayoutManager](https://github.com/GlenKPeterson/PdfLayoutManager)


### PR DESCRIPTION
Adds [dynamic-pdf-tables](https://github.com/the13thclown/dynamic-pdf-tables) to the list of layout/table projects built on PDFBox in the "Can I use PDFBox to create complex layouts?" answer (3.0 FAQ only, as the library requires PDFBox 3.x).

dynamic-pdf-tables is an Apache-2.0 licensed table building library on PDFBox 3.x: dynamic tables with automatic pagination at element granularity (cells and even single elements split across pages), repeating headers, row/column spans, nested tables, text/image/nested-table content, and hooks for cross-page references ("page X of Y"). Released on Maven Central as `io.github.the13thclown:dynamic-pdf-tables` (0.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
